### PR TITLE
export fromReact

### DIFF
--- a/src/Pux.purs
+++ b/src/Pux.purs
@@ -13,6 +13,7 @@ module Pux
   , renderToString
   , start
   , toReact
+  , fromReact
   ) where
 
 import Control.Monad.Aff (Aff, launchAff, later)
@@ -27,7 +28,7 @@ import Data.Maybe (fromJust)
 import Partial.Unsafe (unsafePartial)
 import Prelude (Unit, ($), (<<<), map, pure)
 import Prelude as Prelude
-import Pux.Html (Html)
+import Pux.Html (Attribute, Html)
 import React (ReactClass)
 import Signal (Signal, (~>), mergeMany, foldp, runSignal)
 import Signal.Channel (CHANNEL, Channel, channel, subscribe, send)
@@ -149,3 +150,9 @@ foreign import renderToString :: forall a eff. Signal (Html a) -> Eff eff String
 foreign import toReact :: forall a props eff.
                           Signal (Html a) ->
                           Eff eff (ReactClass props)
+
+foreign import fromReact :: forall component a.
+                            component ->
+                            (Array (Attribute a) ->
+                             Array (Html a) ->
+                             Html a)


### PR DESCRIPTION
in anticipation of switching to psc-package.

the issue is that we have code that uses `require('purescript-pux')` which, under Bower, loads the js foreign file, which exports the `fromReact` function. however with psc-package I don't believe we can load the foreign js file without some hackery.

Better -- I think -- to `require('Pux')` from the compiled purescript module (under `output`). and it needs to export fromReact so that we can use it, hence this PR.